### PR TITLE
Fix intermittent import failure for firmware 1.15C

### DIFF
--- a/src/Elektron/Digitakt/Verify.elm
+++ b/src/Elektron/Digitakt/Verify.elm
@@ -107,8 +107,14 @@ validateProject inst proj =
       |> (\allThere -> if allThere then TestPass () else TestFail resultIfMissing)
 
     missingPatterns =
-      testAllThere proj.patterns
-        "Project dump does not have all the patterns."
+      -- Firmware 1.15C (and possibly others) may not send SysEx messages for
+      -- every pattern slot -- empty patterns can be omitted. Treat missing
+      -- patterns as a warning rather than a hard failure so the project can
+      -- still be loaded.
+      Bank.toArray proj.patterns
+      |> Array.foldl (Maybe.isJust >> (&&)) True
+      |> (\allThere -> if allThere then TestPass ()
+            else TestWarn () "Project dump does not have all the patterns.")
 
     missingSamples =
       testAllThere proj.samplePool


### PR DESCRIPTION
Fixes #6

Firmware 1.15C does not send a SysEx message for every pattern slot — it omits empty/unused patterns. The app expects all 128 `DTPatternKitResponse` messages, leaving any unoccupied slot as `Nothing` in the patterns bank. `testAllThere` then returns `TestFail`, which aborts the import entirely.

This change makes the missing-patterns check return `TestWarn ()` instead of `TestFail`, consistent with how missing sounds are already handled. The import succeeds, the user sees a warning, and the empty pattern slots remain empty (which is correct — they were empty on the device).

`missingSamples` is intentionally left as `TestFail` since the sample pool arrives in a single `ProjectSettings` SysEx and can never be partially missing.